### PR TITLE
Increase connection check timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Firefox incorrectly displays not connected view. Increased connection check timeout.
+
+## [0.1.0] - 2023-03-05
+
+### Added
+
+- Initial release with session and file system events
+- Display apps by namespace
+- Display links to ODD SDK docs and ODD Devtools issue tracker
+- Clear logs for all namespaces
+- Clear logs for one namespace and jump to most recent event in a namespace
+- Filter events by values in event payload

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -2,8 +2,8 @@
   "description": "Developer tools for debugging ODD applications.",
   "manifest_version": 3,
   "name": "ODD Devtools",
-  "version": "0.1.0",
-  "version_name": "0.1.0 beta",
+  "version": "0.2.0",
+  "version_name": "0.2.0 beta",
   "author": "brian@fission.codes",
   "homepage_url": "https://github.com/oddsdk/odd-devtools",
   "icons": {

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -2,7 +2,7 @@
   "description": "Developer tools for debugging ODD applications.",
   "manifest_version": 3,
   "name": "ODD Devtools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "developer": {
     "name": "Fission",
     "url": "https://github.com/oddsdk/odd-devtools"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "webnative-devtools",
-  "version": "0.1.0",
+  "name": "odd-devtools",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "webnative-devtools",
-      "version": "0.1.0",
+      "name": "odd-devtools",
+      "version": "0.2.0",
       "dependencies": {
         "@zerodevx/svelte-json-view": "^1.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odd-devtools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -168,7 +168,7 @@ function handleBackgroundMessage(message) {
       if (!connection.connected) {
         connectionStore.update(store => ({ ...store, error: 'DebugModeOff' }))
       }
-    }, 1000)
+    }, 2000)
   } else if (message.type === 'ready') {
     // Inject content script if missing
     backgroundPort.postMessage({


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Increase connection check timeout
- [x] Add a CHANGELOG

Firefox was incorrectly displaying the not connected view in the published version of the extension. The logo indicated the connection was active, so this appears to be an issue where we assume the connection failed too soon.

## Link to issue

Closes #45 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
